### PR TITLE
Replace deprecated WebClient with HttpClient in unit tests

### DIFF
--- a/server/src/en/UnitTestEnPlugin/TestEnglish.cs
+++ b/server/src/en/UnitTestEnPlugin/TestEnglish.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 
 namespace UnitTestEnPlugin
 {
@@ -57,9 +58,9 @@ namespace UnitTestEnPlugin
         public void SanitizeBasicNoSanitize()
         {
             string translation;
-            using (WebClient wc = new())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language elp = new Language (translation);
             string testWordInput = "this is a test";
@@ -83,9 +84,9 @@ namespace UnitTestEnPlugin
         public void SanitizeBasicRemoveCurlyBraces()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language elp = new Language(translation);
             string testWordInput = "this is{a}test";
@@ -97,9 +98,9 @@ namespace UnitTestEnPlugin
         public void SanitizeBasicRemoveHtmlStuff()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language elp = new Language(translation);
             string testWordInput = "this is<a>test";
@@ -111,9 +112,9 @@ namespace UnitTestEnPlugin
         public void SingularizeBasic()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language elp = new Language(translation);
             string testWordInput = "dogs";
@@ -125,9 +126,9 @@ namespace UnitTestEnPlugin
         public void SingularizeLessBasic()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language elp = new Language(translation);
             string testWordInput = "children";
@@ -139,9 +140,9 @@ namespace UnitTestEnPlugin
         public void SingularizeNotFound()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language elp = new Language(translation);
             string testWordInput = "xxxx";
@@ -153,9 +154,9 @@ namespace UnitTestEnPlugin
         public void GetLabelsBasic()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language elp = new Language(translation);
             var result = elp.GetLabelValues();
@@ -166,9 +167,9 @@ namespace UnitTestEnPlugin
         public void SynonymBasic()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language elp = new Language(translation);
             var result = elp.GetSynonyms ("car");
@@ -179,9 +180,9 @@ namespace UnitTestEnPlugin
         public void SynonymNotFound()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language elp = new Language(translation);
             var result = elp.GetSynonyms("carxxx");
@@ -192,9 +193,9 @@ namespace UnitTestEnPlugin
         public void ExcludedTerms()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language elp = new Language(translation);
             var result = elp.GetExcludedTerms();
@@ -206,9 +207,9 @@ namespace UnitTestEnPlugin
         public void DoNotAmend()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language elp = new Language(translation);
             var result = elp.GetDoNotAmend();

--- a/server/src/ga/TestGaPlugin/TestGa.cs
+++ b/server/src/ga/TestGaPlugin/TestGa.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System;
 using PxLanguagePlugin.ga;
 using System.Net;
+using System.Net.Http;
 
 namespace TestGaPlugin
 {
@@ -31,9 +32,9 @@ namespace TestGaPlugin
         public void TestGetLabelValuesBasic()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language elp = new Language(translation);
             Language glp = new Language(translation);
@@ -46,9 +47,9 @@ namespace TestGaPlugin
         public void SanitizeBasicNoSanitize()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language glp = new Language(translation);
             string testWordInput = "Is teist é seo";
@@ -60,9 +61,9 @@ namespace TestGaPlugin
         public void SanitizeBasicRemoveCurlyBraces()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language glp = new Language(translation);
             string testWordInput = "Is teist {é} seo";
@@ -74,9 +75,9 @@ namespace TestGaPlugin
         public void SanitizeBasicRemoveHtmlStuff()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language glp = new Language();
             string testWordInput = "Is teist <é> seo";
@@ -88,9 +89,9 @@ namespace TestGaPlugin
         public void SingularizeBasic()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language glp = new Language(translation);
             string testWordInput = "tithe";
@@ -102,9 +103,9 @@ namespace TestGaPlugin
         public void SingularizeLenition()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language glp = new Language(translation);
             string testWordInput = "dteach";
@@ -116,9 +117,9 @@ namespace TestGaPlugin
         public void SingularizeAspiration()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language glp = new Language(translation);
             string testWordInput = "theach";
@@ -130,9 +131,9 @@ namespace TestGaPlugin
         public void SingularizeIrregular()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language glp = new Language(translation);
             string testWordInput = "mná";
@@ -144,9 +145,9 @@ namespace TestGaPlugin
         public void SingularizeNotFound()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language glp = new Language(translation);
             string testWordInput = "xxxx";
@@ -158,9 +159,9 @@ namespace TestGaPlugin
         public void GetLabelsBasic()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language glp = new Language(translation);
             var result = glp.GetLabelValues();
@@ -171,9 +172,9 @@ namespace TestGaPlugin
         public void SynonymBasic()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language glp = new Language(translation);
             var result = glp.GetSynonyms("sochaí");
@@ -184,9 +185,9 @@ namespace TestGaPlugin
         public void SynonymNotFound()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language glp = new Language(translation);
             var result = glp.GetSynonyms("xxxxx");
@@ -197,9 +198,9 @@ namespace TestGaPlugin
         public void ExcludedTerms()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language glp = new Language(translation);
             var result = glp.GetExcludedTerms();
@@ -210,9 +211,9 @@ namespace TestGaPlugin
         public void DoNotAmend()
         {
             string translation;
-            using (WebClient wc = new WebClient())
+            using (HttpClient client = new HttpClient())
             {
-                translation = wc.DownloadString("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json");
+                translation = client.GetStringAsync("https://cdn.jsdelivr.net/gh/CSOIreland/PxLanguagePlugins@2.2.0/server/src/en/PxLanguagePlugin/Resources/language.json").Result;
             }
             Language glp = new Language(translation);
             var result = glp.GetDoNotAmend();


### PR DESCRIPTION
The documentation for .NET states that [WebClient is obsolete](https://learn.microsoft.com/en-us/dotnet/api/system.net.webclient?view=net-9.0#remarks) and should be replaced with HttpClient. This PR patches unit tests which use WebClient.